### PR TITLE
fix the 5.0.0 or greater check

### DIFF
--- a/perl/lunManagement.pl
+++ b/perl/lunManagement.pl
@@ -57,7 +57,7 @@ my $operation = Opts::get_option('operation');
 my $datastore = Opts::get_option('datastore');
 my $datastores = "";
 
-if(Vim::get_service_content()->about->version ne "5.0.0") {
+if(Vim::get_service_content()->about->version =~ /^[1234]\./) {
 	print color("red") . "\nThis script is only supported on vSphere 5.0 or greater\n\n" . color("reset");
 	Util::disconnect();
 	exit 1;


### PR DESCRIPTION
The script didn't work with 5.1.x vCenter - just a 1-line mod to make it check the 'greater than 5\..*' condition rather than 'exactly 5.0.0' condition