### PR TITLE
Update guestOpsManagement.pl

### DIFF
--- a/perl/guestOpsManagement.pl
+++ b/perl/guestOpsManagement.pl
@@ -107,7 +107,7 @@ my $working_dir = Opts::get_option('working_dir');
 my $minimize_app = Opts::get_option('minimize_app');
 
 my $productSupport = "both";
-my @supportedVersion = qw(5.0.0 5.1.0 5.5.0);
+my @supportedVersion = qw(5.0.0 5.1.0 5.5.0 6.0.0);
 my ($authMgr,$fileMgr,$procMgr);
 
 &validateSystem(Vim::get_service_content()->about->version,Vim::get_service_content()->about->productLineId);
@@ -695,7 +695,7 @@ sub validateSystem {
 
         if(!grep(/$ver/,@supportedVersion)) {
                 Util::disconnect();
-                &print("Error: This script only supports vSphere \"@supportedVersion\" or greater!\n\n","red");
+                &print("Error: This script only supports vSphere \"@supportedVersion\" versions!\n\n","red");
                 exit 1;
         }
 


### PR DESCRIPTION
Adding support for vSphere 6.0 and suggesting change to error message in order to limit confusion.

Error used to say the following, which would imply that 6.0 was supported:
Error: This script only supports vSphere "5.0.0 5.1.0 5.5.0" or greater!