### PR TITLE
check cpuid values in Verify-ESXiMicrocodePatch

### DIFF
--- a/powershell/VerifyESXiMicrocodePatch.ps1
+++ b/powershell/VerifyESXiMicrocodePatch.ps1
@@ -133,11 +133,11 @@ Function Verify-ESXiMicrocodePatch {
 
         $cpuFeatures = $vmhost.Config.FeatureCapability
         foreach ($cpuFeature in $cpuFeatures) {
-            if($cpuFeature.key -eq "cpuid.IBRS") {
+            if($cpuFeature.key -eq "cpuid.IBRS" -and $cpuFeature.value -eq 1) {
                 $IBRSPass = $true
-            } elseif($cpuFeature.key -eq "cpuid.IBPB") {
+            } elseif($cpuFeature.key -eq "cpuid.IBPB" -and $cpuFeature.value -eq 1) {
                 $IBPBPass = $true
-            } elseif($cpuFeature.key -eq "cpuid.STIBP") {
+            } elseif($cpuFeature.key -eq "cpuid.STIBP" -and $cpuFeature.value -eq 1) {
                 $STIBPPass = $true
             }
         }


### PR DESCRIPTION
I was going crazy trying to figure out why my hosts said they had the new instructions, but virtual machines were not seeing them.  The code was only checking for the cpuid key names, not the actual value of them.