### PR TITLE
Flag IntelSighting different if CPU affected but not patched

### DIFF
--- a/powershell/VerifyESXiMicrocodePatch.ps1
+++ b/powershell/VerifyESXiMicrocodePatch.ps1
@@ -168,7 +168,12 @@ Function Verify-ESXiMicrocodePatch {
         if ($cpuFamily -eq "06") {
             $intelSighting = $false
             if($intelSightings -contains $cpuSignature) {
-                $intelSighting = $true
+                if ($vmhostAffected -eq $true) {
+                    $intelSighting = $true
+                }
+                else {
+                    $intelSighting = "AffectedOncePatched"
+                }
             }
         }
         else {


### PR DESCRIPTION
Hi @lamw ,
This makes it so that if a CPU that is affected by IntelSighting, but not yet patched it will say 'AffectedOncePatched'.

So here's an example of the old code from my environment:
`
VMHost                     CPU                                             IBRPresent IBPBPresent STIBPresent Affected IntelSighting
------                     ---                                             ---------- ----------- ----------- -------- -------------
          redactedhost1    Intel(R) Xeon(R) CPU E5-4650 v4 @ 2.20GHz            False       False       False     True         True
          redactedhost9    Intel(R) Xeon(R) CPU E5-4650 v3 @ 2.10GHz            False       False       False     True         True
         redactedhost13    Intel(R) Xeon(R) CPU E7- 2870  @ 2.40GHz             False       False       False     True         False
`

And this commit:
`
VMHost                     CPU                                             IBRPresent IBPBPresent STIBPresent Affected IntelSighting
------                     ---                                             ---------- ----------- ----------- -------- -------------
          redactedhost1    Intel(R) Xeon(R) CPU E5-4650 v4 @ 2.20GHz            False       False       False     True         AffectedOncePatched
          redactedhost9    Intel(R) Xeon(R) CPU E5-4650 v3 @ 2.10GHz            False       False       False     True         AffectedOncePatched
         redactedhost13    Intel(R) Xeon(R) CPU E7- 2870  @ 2.40GHz             False       False       False     True         False
`
