### PR TITLE
Fix AffectedOncePatched logic

### DIFF
--- a/powershell/VerifyESXiMicrocodePatch.ps1
+++ b/powershell/VerifyESXiMicrocodePatch.ps1
@@ -169,10 +169,10 @@ Function Verify-ESXiMicrocodePatch {
             $intelSighting = $false
             if($intelSightings -contains $cpuSignature) {
                 if ($vmhostAffected -eq $true) {
-                    $intelSighting = $true
+                    $intelSighting = "AffectedOncePatched"
                 }
                 else {
-                    $intelSighting = "AffectedOncePatched"
+                    $intelSighting = $true
                 }
             }
         }


### PR DESCRIPTION
The logic for the new "AffectedOncePatched" result for IntelSightings was setting that state for hosts which had already been patched and are actively affected, and True for hosts not yet patched. Should be the other way around.