### PR TITLE
Corrected the VM_Network name and also added a delay

### DIFF
--- a/powershell/vRNI-Deploy.ps1
+++ b/powershell/vRNI-Deploy.ps1
@@ -33,7 +33,7 @@ $NTPServer = "172.30.0.100"
 $VMCluster = "Primp-Cluster"
 $VMDatastore = "himalaya-local-SATA-re4gp4T:storage"
 $VMNetwork = "access333"
-$vmhost = "10.197.4.207"  #User can update the Host IP for on which VMs need to be deployed.
+$vmhost = "10.197.4.207"  #Host IP on which VMs need to be deployed.
 
 ### DO NOT EDIT BEYOND HERE ###
 

--- a/powershell/vRNI-Deploy.ps1
+++ b/powershell/vRNI-Deploy.ps1
@@ -1,5 +1,5 @@
 <#
-.SYNOPSIS Script to deploy vRealize Network Insight (vRNI) 3.2 Platform + Proxy VM
+.SYNOPSIS Script to deploy vRealize Network Insight (vRNI) 3.7 Platform + Proxy VM
 .NOTES  Author:  William Lam
 .NOTES  Site:    www.virtuallyghetto.com
 .NOTES  Reference: http://www.virtuallyghetto.com/2016/12/automated-deployment-and-setup-of-vrealize-network-insight-vrni.html

--- a/powershell/vRNI-Deploy.ps1
+++ b/powershell/vRNI-Deploy.ps1
@@ -6,7 +6,7 @@
 #>
 
 # Path to vRNI OVAs
-﻿$vRNIPlatformOVA = "C:\Users\primp\Desktop\VMWare-vRealize-Networking-insight-3.2.0.1480511973-platform.ova"
+$vRNIPlatformOVA = "C:\Users\primp\Desktop\VMWare-vRealize-Networking-insight-3.2.0.1480511973-platform.ova"
 $vRNIProxyOVA = "C:\Users\primp\Desktop\VMWare-vRealize-Networking-insight-3.2.0.1480511973-proxy.ova"
 
 # vRNI License Key
@@ -33,6 +33,7 @@ $NTPServer = "172.30.0.100"
 $VMCluster = "Primp-Cluster"
 $VMDatastore = "himalaya-local-SATA-re4gp4T:storage"
 $VMNetwork = "access333"
+$vmhost = "10.197.4.207"
 
 ### DO NOT EDIT BEYOND HERE ###
 
@@ -55,13 +56,12 @@ $json = $hash | ConvertTo-Json
 
 $location = Get-Cluster $VMCluster
 $datastore = Get-Datastore -Name $VMDatastore
-$vmhost = Get-VMHost
-$network = Get-VirtualPortGroup -Name $VMNetwork -VMHost $vmhost[0]
+$network = Get-VirtualPortGroup -Name $VMNetwork -VMHost $vmhost
 $vRNIPlatformOVFConfig = Get-OvfConfiguration $vRNIPlatformOVA
 $vRNIProxyOVFConfig = Get-OvfConfiguration $vRNIProxyOVA
 
 $vRNIPlatformOVFConfig.DeploymentOption.Value = $DeploymentSize
-$vRNIPlatformOVFConfig.NetworkMapping.Vlan256_corp_2.Value = $VMNetwork
+$vRNIPlatformOVFConfig.NetworkMapping.VM_Network.Value = $VMNetwork
 $vRNIPlatformOVFConfig.Common.IP_Address.Value = $vRNIPlatformIPAddress
 $vRNIPlatformOVFConfig.Common.Netmask.Value = $vRNIPlatformNetmask
 $vRNIPlatformOVFConfig.Common.Default_Gateway.Value = $vRNIPlatformGateway
@@ -70,7 +70,7 @@ $vRNIPlatformOVFConfig.Common.Domain_Search.Value = $DNSDomain
 $vRNIPlatformOVFConfig.Common.NTP.Value = $NTPServer
 
 $vRNIProxyOVFConfig.DeploymentOption.Value = $DeploymentSize
-$vRNIProxyOVFConfig.NetworkMapping.Vlan256_corp_2.Value = $VMNetwork
+$vRNIProxyOVFConfig.NetworkMapping.VM_Network.Value = $VMNetwork
 $vRNIProxyOVFConfig.Common.IP_Address.Value = $vRNIProxyIPAddress
 $vRNIProxyOVFConfig.Common.Netmask.Value = $vRNIProxyNetmask
 $vRNIProxyOVFConfig.Common.Default_Gateway.Value = $vRNIProxyGateway
@@ -84,6 +84,8 @@ $vRNIPlatformVM = Import-VApp -OvfConfiguration $vRNIPlatformOVFConfig -Source $
 My-Logger "Starting vRNI Platform VM ..."
 Start-VM -VM $vRNIPlatformVM -Confirm:$false | Out-Null
 
+My-Logger "Waiting for 600 seconds for services on platform to come up ..."
+sleep 600
 My-Logger "Checking to see if vRNI Platform VM is ready ..."
 while(1) {
     try {

--- a/powershell/vRNI-Deploy.ps1
+++ b/powershell/vRNI-Deploy.ps1
@@ -56,6 +56,9 @@ $json = $hash | ConvertTo-Json
 
 $location = Get-Cluster $VMCluster
 $datastore = Get-Datastore -Name $VMDatastore
+# Removed Get-VMHost and moved it to vRNI Deployment Settings so that user can provide even the Host
+#$vmhost = Get-VMHost
+#$network = Get-VirtualPortGroup -Name $VMNetwork -VMHost $vmhost[0]
 $network = Get-VirtualPortGroup -Name $VMNetwork -VMHost $vmhost
 $vRNIPlatformOVFConfig = Get-OvfConfiguration $vRNIPlatformOVA
 $vRNIProxyOVFConfig = Get-OvfConfiguration $vRNIProxyOVA

--- a/powershell/vRNI-Deploy.ps1
+++ b/powershell/vRNI-Deploy.ps1
@@ -33,7 +33,7 @@ $NTPServer = "172.30.0.100"
 $VMCluster = "Primp-Cluster"
 $VMDatastore = "himalaya-local-SATA-re4gp4T:storage"
 $VMNetwork = "access333"
-$vmhost = "10.197.4.207"
+$vmhost = "10.197.4.207"  #User can update the Host IP for on which VMs need to be deployed.
 
 ### DO NOT EDIT BEYOND HERE ###
 

--- a/powershell/vRNI-Deploy.ps1
+++ b/powershell/vRNI-Deploy.ps1
@@ -56,7 +56,7 @@ $json = $hash | ConvertTo-Json
 
 $location = Get-Cluster $VMCluster
 $datastore = Get-Datastore -Name $VMDatastore
-# Removed Get-VMHost and moved it to vRNI Deployment Settings so that user can provide even the Host
+# Removed Get-VMHost and moved it to vRNI Deployment Settings so that user can provide even the Host IP
 #$vmhost = Get-VMHost
 #$network = Get-VirtualPortGroup -Name $VMNetwork -VMHost $vmhost[0]
 $network = Get-VirtualPortGroup -Name $VMNetwork -VMHost $vmhost


### PR DESCRIPTION
Updated logic of deployment:
- Corrected NetworkMapping. VM_Network
- Added delay for services to come up on platform.
- Removed logic to get Host for deployment and added vmhost parameter in vRNI Deployment Settings section so that user can also update the Host IP alongwith cluster datastore and network.