### PR TITLE
updated for new microcode (and white space confusion)

### DIFF
--- a/powershell/VerifyESXiMicrocodePatch.ps1
+++ b/powershell/VerifyESXiMicrocodePatch.ps1
@@ -98,7 +98,7 @@ Function Verify-ESXiMicrocodePatch {
     .DESCRIPTION
         This function helps verify only the ESXi Microcode update has been
         applied as stated per https://kb.vmware.com/s/article/52085
-        
+
         This script can return all ESXi hosts or you can specify
         a vSphere Cluster to limit the scope or an individual ESXi host
     .PARAMETER VMHostName

--- a/powershell/VerifyESXiMicrocodePatch.ps1
+++ b/powershell/VerifyESXiMicrocodePatch.ps1
@@ -10,7 +10,7 @@ Function Verify-ESXiMicrocodePatchAndVM {
     .DESCRIPTION
         This function helps verify both ESXi Patch and Microcode updates have been
         applied as stated per https://kb.vmware.com/s/article/52085
-        
+
         This script can return all VMs or you can specify
         a vSphere Cluster to limit the scope or an individual VM
     .PARAMETER VMName

--- a/powershell/VerifyESXiMicrocodePatch.ps1
+++ b/powershell/VerifyESXiMicrocodePatch.ps1
@@ -10,6 +10,7 @@ Function Verify-ESXiMicrocodePatchAndVM {
     .DESCRIPTION
         This function helps verify both ESXi Patch and Microcode updates have been
         applied as stated per https://kb.vmware.com/s/article/52085
+        
         This script can return all VMs or you can specify
         a vSphere Cluster to limit the scope or an individual VM
     .PARAMETER VMName
@@ -97,6 +98,7 @@ Function Verify-ESXiMicrocodePatch {
     .DESCRIPTION
         This function helps verify only the ESXi Microcode update has been
         applied as stated per https://kb.vmware.com/s/article/52085
+        
         This script can return all ESXi hosts or you can specify
         a vSphere Cluster to limit the scope or an individual ESXi host
     .PARAMETER VMHostName


### PR DESCRIPTION
Removed most of Intel Sightings logic as you are either on the affected ucode or not. It's unlikely you are going to install one of the withdrawn patches or BIOS updates rather than the new, fixed ones.

Put signatures and ucode revisions into an array (revisions aren't unique across different models).

Added processor signature and whether the ucode is "known good" (we hope) to the table.

(it somehow seems my last change isn't on your master? should not be a hard conflict though, let me know if it looks off and I just start over)