### PR TITLE
update for new microcode 

### DIFF
--- a/powershell/VerifyESXiMicrocodePatch.ps1
+++ b/powershell/VerifyESXiMicrocodePatch.ps1
@@ -98,7 +98,7 @@ Function Verify-ESXiMicrocodePatch {
     .DESCRIPTION
         This function helps verify only the ESXi Microcode update has been
         applied as stated per https://kb.vmware.com/s/article/52085
-        
+
         This script can return all ESXi hosts or you can specify
         a vSphere Cluster to limit the scope or an individual ESXi host
     .PARAMETER VMHostName

--- a/powershell/VerifyESXiMicrocodePatch.ps1
+++ b/powershell/VerifyESXiMicrocodePatch.ps1
@@ -133,10 +133,10 @@ Function Verify-ESXiMicrocodePatch {
     }
 
     #List from https://kb.vmware.com/s/article/52345
-    $intelSightings = @("0x000306C3", "0x000306F2", "0x000306F4", "0x00040671", "0x000406F1", "0x000406F1", "0x00050663")
+    $intelSightings = @("0x000306C3", "0x000306E4", "0x000306F2", "0x000306F4", "0x00040671", "0x000406F1", "0x00050654", "0x00050663", "0x000506E3", "0x000906E9")
 
     #List of blacklisted Microcode containing Intel Sighting issue from https://kb.vmware.com/s/article/52345
-    $intelSightingsMicrocodeVersion = @("0x00000023", "0x00000023", "0x0000003B", "0x0000001B", "0x0B000025", "0x07000011")
+    $intelSightingsMicrocodeVersion = @("0x00000023", "0x0000042A", "0x0000003B", "0x00000010", "0x0000001B", "0x0B000025", "0x0200003A", "0x07000011", "0x000000C2", "0x0000007C")
 
     # Remote SSH commands for retrieving current ESXi host microcode version
     $plinkoptions = "-ssh -pw $ESXiPassword"

--- a/powershell/VerifyESXiMicrocodePatch.ps1
+++ b/powershell/VerifyESXiMicrocodePatch.ps1
@@ -10,7 +10,7 @@ Function Verify-ESXiMicrocodePatchAndVM {
     .DESCRIPTION
         This function helps verify both ESXi Patch and Microcode updates have been
         applied as stated per https://kb.vmware.com/s/article/52085
-        
+
         This script can return all VMs or you can specify
         a vSphere Cluster to limit the scope or an individual VM
     .PARAMETER VMName

--- a/powershell/VerifyESXiMicrocodePatch.ps1
+++ b/powershell/VerifyESXiMicrocodePatch.ps1
@@ -10,6 +10,7 @@ Function Verify-ESXiMicrocodePatchAndVM {
     .DESCRIPTION
         This function helps verify both ESXi Patch and Microcode updates have been
         applied as stated per https://kb.vmware.com/s/article/52085
+        
         This script can return all VMs or you can specify
         a vSphere Cluster to limit the scope or an individual VM
     .PARAMETER VMName
@@ -97,6 +98,7 @@ Function Verify-ESXiMicrocodePatch {
     .DESCRIPTION
         This function helps verify only the ESXi Microcode update has been
         applied as stated per https://kb.vmware.com/s/article/52085
+        
         This script can return all ESXi hosts or you can specify
         a vSphere Cluster to limit the scope or an individual ESXi host
     .PARAMETER VMHostName


### PR DESCRIPTION
this time without conflicts :-)

Removed most of Intel Sightings logic as you are either on the affected ucode or not. It's unlikely you are going to install one of the withdrawn patches or BIOS updates rather than the new, fixed ones.

Put signatures and ucode revisions into an array (revisions aren't unique across different models).

Added processor signature and whether the ucode is "known good" (we hope) to the table.