### PR TITLE
Add Credential Usage

### DIFF
--- a/powershell/xMove-VM.ps1
+++ b/powershell/xMove-VM.ps1
@@ -198,13 +198,13 @@ add-type @"
 
 # Variables that must be defined
 
+$sourceVCCred = Get-Credential -Message "Source vCenter Server Credentials"
+$destVCCred = Get-Credential -Message "Destination vCenter Server Credentials"
+$destVCusername = $destVCCred.GetNetworkCredential().username
+$destVCpassword = $destVCCred.GetNetworkCredential().password
 $vmname = "TinyVM-2"
 $sourceVC = "vcenter60-1.primp-industries.com"
-$sourceVCUsername = "administrator@vghetto.local"
-$sourceVCPassword = "VMware1!"
 $destVC = "vcenter60-3.primp-industries.com"
-$destVCUsername = "administrator@vghetto.local"
-$destVCpassword = "VMware1!"
 $datastorename = "la-datastore1"
 $resourcepool = "WorkloadRP"
 $vmhostname = "vesxi60-5.primp-industries.com"
@@ -215,8 +215,8 @@ $ComputeXVC = 1
 $UppercaseUUID = $false
 
 # Connect to Source/Destination vCenter Server
-$sourceVCConn = Connect-VIServer -Server $sourceVC -user $sourceVCUsername -password $sourceVCPassword
-$destVCConn = Connect-VIServer -Server $destVC -user $destVCUsername -password $destVCpassword
+$sourceVCConn = Connect-VIServer -Server $sourceVC -Credential $sourceVCCred
+$destVCConn = Connect-VIServer -Server $destVC -Credential $destVCCred
 
 xMove-VM -sourcevc $sourceVCConn -destvc $destVCConn -VM $vmname -switchtype $switchtype -switch $switchname -resourcepool $resourcepool -vmhost $vmhostname -datastore $datastorename -vmnetwork  $vmnetworkname -xvcType $computeXVC -uppercaseuuid $UppercaseUUID
 


### PR DESCRIPTION
Small change to replace plain text user/pass entries with Powershell credentials. This will eliminate the need for plain text passwords being stored in the script itself and will help avoid accidental leaking of administrator usernames/passwords.