### PR TITLE
Update ESXiBootDevice.ps1 to return stateless boot correctly

### DIFF
--- a/powershell/ESXiBootDevice.ps1
+++ b/powershell/ESXiBootDevice.ps1
@@ -50,10 +50,10 @@
             $option.option = "/UserVars/ImageCachedSystem"
             try {
                 $optionValue = $esxcli.system.settings.advanced.list.Invoke($option)
+                $bootType = $optionValue.StringValue
             } catch {
                 $bootType = "stateless"
             }
-            $bootType = $optionValue.StringValue
         }
 
         # Loop through all storage devices to identify boot device


### PR DESCRIPTION
In my environment (6.5 U2) with stateless boot, the "$bootType = $optionValue.StringValue" always overwrites the $boottype = "stateless" even if the catch block triggers.
Moving the assignment inside the try block will return proper results