### PR TITLE
create_custom_esxi_iso.ps1: Print base image path correctly

### DIFF
--- a/powershell/create_custom_esxi_iso.ps1
+++ b/powershell/create_custom_esxi_iso.ps1
@@ -21,7 +21,7 @@ if($PSVersionTable.PSEdition -ne "Desktop") {
     exit
 }
 
-Write-Host -Foreground cyan "Processing ESXi Base Image $ESXIDriver ..."
+Write-Host -Foreground cyan "Processing ESXi Base Image $ESXIBaseImagePath ..."
 $ESXIBaseImageVersion = (Get-DepotBaseImages -Depot $ESXIBaseImagePath).Version
 
 # Build list of Components from ESXi Drivers


### PR DESCRIPTION
`$ESXIDriver` is undefined. It should be `$ESXIBaseImagePath`.

Example output difference:
```diff
 PS C:\users\jason\desktop\custom-esxi-image> .\create_custom_esxi_iso.ps1
-Processing ESXi Base Image  ...
+Processing ESXi Base Image C:\Users\jason\Desktop\custom-esxi-image\VMware-ESXi-7.0U3c-19193900-depot.zip ...
 Processing ESXi Driver C:\Users\jason\Desktop\custom-esxi-image\Net-Community-Driver_1.2.7.0-1vmw.700.1.0.15843807_19480755.zip ...
 Processing ESXi Driver C:\Users\jason\Desktop\custom-esxi-image\nvme-community-driver_1.0.1.0-3vmw.700.1.0.15843807-component-18902434.zip ...
```
