### PR TITLE
create_custom_vsan_esa_hcl_json.ps1 - ensure hex values have leading zeros

### DIFF
--- a/powershell/create_custom_vsan_esa_hcl_json.ps1
+++ b/powershell/create_custom_vsan_esa_hcl_json.ps1
@@ -28,10 +28,10 @@ foreach ($storageDevice in $storageDevices) {
                 $pciDevice = $pciDevices | where {$_.Id -eq $storageAdapter.Pci}
 
                 # Convert from Dec to Hex
-                $vid = ('{0:x}' -f $pciDevice.VendorId).ToLower()
-                $did = ('{0:x}' -f $pciDevice.DeviceId).ToLower()
-                $svid = ('{0:x}' -f $pciDevice.SubVendorId).ToLower()
-                $ssid = ('{0:x}' -f $pciDevice.SubDeviceId).ToLower()
+                $vid = ('{0:x4}' -f $pciDevice.VendorId).ToLower()
+                $did = ('{0:x4}' -f $pciDevice.DeviceId).ToLower()
+                $svid = ('{0:x4}' -f $pciDevice.SubVendorId).ToLower()
+                $ssid = ('{0:x4}' -f $pciDevice.SubDeviceId).ToLower()
                 $combined = "${vid}:${did}:${svid}:${ssid}"
 
                 if($storageAdapter.Driver -eq "nvme_pcie" -or $storageAdapter.Driver -eq "pvscsi") {


### PR DESCRIPTION
This will ensure all of the hex values in the generated HCL will be 4 hex digits long (i.e. have leading 0's).

For example, on some hardware in my lab the script originally generated this:
```
        "did": "953",
        "vid": "8086",
        "ssid": "370b",
        "svid": "108e",
```

when it should have been:
```
        "did": "0953",
        "vid": "8086",
        "ssid": "370b",
        "svid": "108e",
```